### PR TITLE
handle needs to specify type of exception

### DIFF
--- a/9-a-library-for-searching-the-file-system.org
+++ b/9-a-library-for-searching-the-file-system.org
@@ -500,7 +500,7 @@ that could cause spurious failures elsewhere in our program.
 
 #+CAPTION: BetterPredicate.hs
 #+BEGIN_SRC haskell
-getFileSize path = handle (\_ -> return Nothing) $
+getFileSize path = handle ((\_ -> return Nothing) :: IOError -> IO (Maybe Integer)) $
   bracket (openFile path ReadMode) hClose $ \h -> do
     size <- hFileSize h
     return (Just size)


### PR DESCRIPTION
I tried to run this as is and my compiler errored:

```
    • Ambiguous type variable ‘e0’ arising from a use of ‘handle’
      prevents the constraint ‘(GHC.Exception.Type.Exception
                                  e0)’ from being solved.
      Probable fix: use a type annotation to specify what ‘e0’ should be.
      These potential instances exist:
        instance GHC.Exception.Type.Exception SomeException
          -- Defined in ‘GHC.Exception.Type’
        ...plus 9 instances involving out-of-scope types
        (use -fprint-potential-instances to see them all)
    • In the expression: handle (\ _ -> return Nothing)
      In the expression:
        handle (\ _ -> return Nothing)
          $ bracket (openFile path ReadMode) hClose
              $ \ h
                  -> do size <- hFileSize h
                        return (Just size)
      In an equation for ‘getFileSize’:
          getFileSize path
            = handle (\ _ -> return Nothing)
                $ bracket (openFile path ReadMode) hClose
                    $ \ h
                        -> do size <- hFileSize h
```