### PR TITLE
Missing type definitions in example

### DIFF
--- a/17-interfacing-with-c.org
+++ b/17-interfacing-with-c.org
@@ -553,11 +553,11 @@ removed for brevity):
 
 #+CAPTION: Regex.hs
 #+BEGIN_SRC haskell
-caseless
+caseless              :: PCREOption
 caseless              = PCREOption 1
-dollar_endonly
+dollar_endonly        :: PCREOption
 dollar_endonly        = PCREOption 32
-dotall
+dotall                :: PCREOption
 dotall                = PCREOption 4
 #+END_SRC
 

--- a/17-interfacing-with-c.org
+++ b/17-interfacing-with-c.org
@@ -475,7 +475,7 @@ variables have been expanded, yielding valid Haskell code:
 
 #+CAPTION: Regex-hsc-const-generated.hs
 #+BEGIN_SRC haskell
-caseless
+caseless       :: PCREOption
 caseless       = PCREOption 1
 {-# LINE 21 "Regex.hsc" #-}
 
@@ -483,7 +483,7 @@ dollar_endonly :: PCREOption
 dollar_endonly = PCREOption 32
 {-# LINE 24 "Regex.hsc" #-}
 
-dotall
+dotall         :: PCREOption
 dotall         = PCREOption 4
 {-# LINE 27 "Regex.hsc" #-}
 #+END_SRC

--- a/17-interfacing-with-c.org
+++ b/17-interfacing-with-c.org
@@ -446,13 +446,13 @@ the ~#const~ keyword:
 
 #+CAPTION: Regex-hsc-const.hs
 #+BEGIN_SRC haskell
-caseless
+caseless       :: PCREOption
 caseless       = PCREOption #const PCRE_CASELESS
 
 dollar_endonly :: PCREOption
 dollar_endonly = PCREOption #const PCRE_DOLLAR_ENDONLY
 
-dotall
+dotall         :: PCREOption
 dotall         = PCREOption #const PCRE_DOTALL
 #+END_SRC
 


### PR DESCRIPTION
I think these might have gone missing?