### PR TITLE
Update internal unqualified references to Chapter 14

### DIFF
--- a/10-parsing-a-binary-data-format.org
+++ b/10-parsing-a-binary-data-format.org
@@ -5,7 +5,7 @@ file. We will use this task for two purposes. Our first is indeed
 to talk a little about parsing, but our main goal is to talk about
 program organisation, refactoring, and “boilerplate removal”. We
 will demonstrate how you can tidy up repetitious code, and set the
-stage for our discussion of monads in [[file:monads.html][Chapter 14, /Monads/]].
+stage for our discussion of monads in [[file:15-monads.org][Chapter 14, Monads]].
 
 The file formats that we will work with come from the netpbm
 suite, an ancient and venerable collection of programs and file
@@ -1148,7 +1148,7 @@ parameterised type.
 
 We will revisit parsing in [[file:using-parsec.html][Chapter 16, /Using Parsec/]], to discuss
 Parsec, a widely used and flexible parsing library. And in
-[[file:monads.html][Chapter 14, /Monads/]], we will return to our theme of abstraction,
+[[file:15-monads.org][Chapter 14, Monads]], we will return to our theme of abstraction,
 where we will find that much of the code that we have developed in
 this chapter can be further simplified by the use of monads.
 

--- a/16-programming-with-monads.org
+++ b/16-programming-with-monads.org
@@ -171,7 +171,7 @@ ghci> :type ap
 ap :: Monad m => m (a -> b) -> m a -> m b
 #+END_SRC
 
-And that's why, as we saw in [[file:monads.html][Chapter 15, /Monads/]], they are
+And that's why, as we saw in [[file:15-monads.org][Chapter 15, /Monads/]], they are
 synonyms.
 
 ** Looking for alternatives

--- a/16-programming-with-monads.org
+++ b/16-programming-with-monads.org
@@ -171,7 +171,7 @@ ghci> :type ap
 ap :: Monad m => m (a -> b) -> m a -> m b
 #+END_SRC
 
-And that's why, as we saw in [[file:15-monads.org][Chapter 15, /Monads/]], they are
+And that's why, as we saw in [[file:15-monads.org][Chapter 15, Monads]], they are
 synonyms.
 
 ** Looking for alternatives

--- a/19-error-handling.org
+++ b/19-error-handling.org
@@ -227,7 +227,7 @@ Back in [[file:error-handling.html#errors.maybe][the section called “Use of Ma
 program named ~divby2.hs~. This example didn't preserve laziness,
 but returned a value of type ~Maybe [a]~. The exact same algorithm
 could be expressed using a monadic style. For more information and
-important background on monads, please refer to [[file:monads.html][Chapter 14, /Monads/]].
+important background on monads, please refer to [[file:15-monads.org][Chapter 14, /Monads/]].
 Here's our new monadic-style algorithm:
 
 #+CAPTION: divby4.hs

--- a/7-io.org
+++ b/7-io.org
@@ -1116,7 +1116,7 @@ in Haskell is called /actions/. Actions resemble functions. They
 do nothing when they are defined, but perform some task when they
 are invoked. I/O actions are defined within the IO monad. Monads
 are a powerful way of chaining functions together purely and are
-covered in [[file:monads.html][Chapter 14, /Monads/]]. It's not necessary to understand
+covered in [[file:15-monads.org][Chapter 14, /Monads/]]. It's not necessary to understand
 monads in order to understand I/O. Just understand that the result
 type of actions is "tagged" with IO. Let's take a look at some
 types:


### PR DESCRIPTION
Translation had retained links to "monads.html"; this points to "15-monads.org".

A similar fix can be applied for other chapters.